### PR TITLE
Port MastermindIRCBot to Python 3.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,8 @@
+# -*- coding: utf-8 -*-
 """Base IRC Bot that abstracts the boilerplate from the actual logic."""
 
-import irclib
-import ircbot
+import irc.client
+import irc.bot as ircbot
 import sys
 
 import masterbot
@@ -51,11 +52,11 @@ class IRCBot(ircbot.SingleServerIRCBot):
 
     def GetAuthor(self):
         """Returns the nickname of the author of the latest message."""
-        return irclib.nm_to_n(self._ev.source())
+        return irc.client.nm_to_n(self._ev.source())
 
     def GetMessage(self):
         """Returns the latest message."""
-        return self._ev.arguments()[0].lower()
+        return self._ev.arguments[0].lower()
 
     def SendMessage(self, message, message_to=None):
         """Sends a message to a specific user or to the whole chan."""

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,11 @@
 """Utils for the game of Mastermind."""
 
 import collections
-import functools32  # ircbot doesn't exist for Python 3 so we must import this.
+import functools
 import itertools
 
 
-@functools32.lru_cache(maxsize=2401)  # Up to 7^4 values.
+@functools.lru_cache(maxsize=2401)  # Up to 7^4 values.
 def _GetCount(max_value, num_digits, code):
     """Returns the count of each character from the code.
 
@@ -38,17 +38,17 @@ def ComputeProximity(max_value, num_digits, code_1, code_2):
     return black, black_and_white - black
 
 
-@functools32.lru_cache()
+@functools.lru_cache()
 def GetAllCodes(max_value, num_digits):
     """Returns all possible codes for a given max_value and num_digits.
 
     The length of the returned list is max_value ** num_digits.
     """
-    all_codes = itertools.product(xrange(1, max_value + 1), repeat=num_digits)
+    all_codes = itertools.product(range(1, max_value + 1), repeat=num_digits)
     return [''.join(str(digit) for digit in digits) for digits in all_codes]
 
 
-@functools32.lru_cache(maxsize=1)
+@functools.lru_cache(maxsize=1)
 def _GetPossibilitiesDict(max_value, num_digits):
     """Returns a dict matching a code and a proximity to all the matching codes.
 


### PR DESCRIPTION
This PR ports MastermindIRCBot both to Python3 and to a newer version of the irc lib installable with pip. This makes it easier to use the bot on another distribution.

I should probably add install instructions (something along the line of `sudo pip install "irc==8.5.3").